### PR TITLE
Add Epic Installation Detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ IdleCombos.ahk.bak
 userdetails.json
 idlecombosettings.json
 idlecombolog.txt
+eos_loader_log.txt
 .vscode/settings.json

--- a/IdleCombos.ahk
+++ b/IdleCombos.ahk
@@ -69,6 +69,17 @@ global RedeemCodeLogFile := "redeemcodelog.json"
 global JournalFile := "journal.json"
 global CurrentSettings := []
 global GameInstallDir := "C:\Program Files (x86)\Steam\steamapps\common\IdleChampions\"
+global GameClientEpic := "C:\ProgramData\Epic\UnrealEngineLauncher\LauncherInstalled.dat"
+if FileExist(GameClientEpic) {
+	FileRead, EpicJSONString, %GameClientEpic%
+	EpicJSONobj := JSON.parse(EpicJSONString)
+	for each, item in EpicJSONobj.InstallationList {
+		if item.AppName = "40cb42e38c0b4a14a1bb133eb3291572" {
+			GameInstallDir := item.InstallLocation "\"
+			break
+		}
+	}
+}
 global WRLFile := GameInstallDir "IdleDragons_Data\StreamingAssets\downloaded_files\webRequestLog.txt"
 global DictionaryFile := "https://raw.githubusercontent.com/dhusemann/idlecombos/master/idledict.ahk"
 global LocalDictionary := "idledict.ahk"

--- a/IdleCombos.ahk
+++ b/IdleCombos.ahk
@@ -70,12 +70,14 @@ global JournalFile := "journal.json"
 global CurrentSettings := []
 global GameInstallDir := "C:\Program Files (x86)\Steam\steamapps\common\IdleChampions\"
 global GameClientEpic := "C:\ProgramData\Epic\UnrealEngineLauncher\LauncherInstalled.dat"
+global GameClientEpicLauncher := ""
 if FileExist(GameClientEpic) {
 	FileRead, EpicJSONString, %GameClientEpic%
 	EpicJSONobj := JSON.parse(EpicJSONString)
 	for each, item in EpicJSONobj.InstallationList {
 		if item.AppName = "40cb42e38c0b4a14a1bb133eb3291572" {
 			GameInstallDir := item.InstallLocation "\"
+			GameClientEpicLauncher := "com.epicgames.launcher://apps/40cb42e38c0b4a14a1bb133eb3291572?action=launch&silent=true"
 			break
 		}
 	}
@@ -88,6 +90,9 @@ global ICSettingsFile := A_AppData
 StringTrimRight, ICSettingsFile, ICSettingsFile, 7
 ICSettingsFile := ICSettingsFile "LocalLow\Codename Entertainment\Idle Champions\localSettings.json"
 global GameClient := GameInstallDir "IdleDragons.exe"
+if GameClientEpicLauncher != ""
+	GameClient := GameClientEpicLauncher
+
 
 ;Settings globals
 global ServerName := "ps7"

--- a/IdleCombos.ahk
+++ b/IdleCombos.ahk
@@ -69,15 +69,16 @@ global RedeemCodeLogFile := "redeemcodelog.json"
 global JournalFile := "journal.json"
 global CurrentSettings := []
 global GameInstallDir := "C:\Program Files (x86)\Steam\steamapps\common\IdleChampions\"
+global GameIDEpic := "40cb42e38c0b4a14a1bb133eb3291572"
 global GameClientEpic := "C:\ProgramData\Epic\UnrealEngineLauncher\LauncherInstalled.dat"
 global GameClientEpicLauncher := ""
 if FileExist(GameClientEpic) {
 	FileRead, EpicJSONString, %GameClientEpic%
 	EpicJSONobj := JSON.parse(EpicJSONString)
 	for each, item in EpicJSONobj.InstallationList {
-		if item.AppName = "40cb42e38c0b4a14a1bb133eb3291572" {
+		if item.AppName = GameIDEpic {
 			GameInstallDir := item.InstallLocation "\"
-			GameClientEpicLauncher := "com.epicgames.launcher://apps/40cb42e38c0b4a14a1bb133eb3291572?action=launch&silent=true"
+			GameClientEpicLauncher := "com.epicgames.launcher://apps/" GameIDEpic "?action=launch&silent=true"
 			break
 		}
 	}


### PR DESCRIPTION
Added detection of the Idle Champions installation location via the Epic Games

This will detect EPIC first, then fallback on STEAM, which may be an issue if you have installations from both platforms.

Mentioned in Issue #3 